### PR TITLE
chore(attributes-panel): remove unused code

### DIFF
--- a/src/components/attributes-panel/attributes-panel.tsx
+++ b/src/components/attributes-panel/attributes-panel.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
-const Container = styled.div<{ isControlPanelShown: boolean }>`
+const Container = styled.div`
   position: absolute;
   top: 70px;
   right: 10px;
@@ -76,7 +76,6 @@ const NO_DATA = "No Data";
 interface AttributesPanelProps {
   title: string;
   attributesObject: any;
-  isControlPanelShown: boolean;
   handleClosePanel: () => void;
   children?: any;
 }
@@ -87,7 +86,6 @@ interface AttributesPanelProps {
 export const AttributesPanel = ({
   title,
   attributesObject,
-  isControlPanelShown,
   handleClosePanel,
   children = null,
 }: AttributesPanelProps) => {
@@ -136,7 +134,7 @@ export const AttributesPanel = ({
   };
 
   return (
-    <Container isControlPanelShown={isControlPanelShown}>
+    <Container>
       {renderHeader()}
       <ContentWrapper>
         {attributesObject && prepareTable()}

--- a/src/pages/debug-app/debug-app.tsx
+++ b/src/pages/debug-app/debug-app.tsx
@@ -1015,7 +1015,6 @@ export const DebugApp = () => {
         title={title}
         handleClosePanel={handleClosePanel}
         attributesObject={tileInfo}
-        isControlPanelShown={debugOptions.controlPanel}
       >
         <TileValidator
           tile={selectedTile}

--- a/src/pages/viewer-app/viewer-app.tsx
+++ b/src/pages/viewer-app/viewer-app.tsx
@@ -11,7 +11,7 @@ import {
   FlyToInterpolator,
   COORDINATE_SYSTEM,
   MapView,
-  WebMercatorViewport
+  WebMercatorViewport,
 } from "@deck.gl/core";
 import { TerrainLayer, Tile3DLayer } from "@deck.gl/geo-layers";
 import {
@@ -555,7 +555,6 @@ export const ViewerApp = () => {
         title={title}
         handleClosePanel={handleClosePanel}
         attributesObject={selectedFeatureAttributes}
-        isControlPanelShown
       />
     );
   };


### PR DESCRIPTION
There was a refactoring while moving these code from loader.gl and `isControlPanelShown` prop was passed by mistake.