### PR TITLE
chore(local-deck): change webpack.dev configuration

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -51,6 +51,30 @@ function getAliasesForLocalDependencies(env) {
   return aliases;
 }
 
+/**
+ * Returns loader for 'ts' and 'tsx' files.
+ * If we are using '--deck' env variable we should avoid TypeScript issues from deck.gl folder.
+ * TODO: We should always use ts-loader once all issues with deck.gl types have been resolved.
+ */
+function getLoaders(env) {
+  // Use simple babel loader without typescript to avoid local deck.gl typing issues.
+  if (env["deck"]) {
+    return {
+      loader: "babel-loader",
+      options: {
+        presets: [
+          "@babel/preset-env",
+          ["@babel/preset-react", { runtime: "automatic" }],
+        ],
+      },
+    };
+  }
+
+  return {
+    loader: "ts-loader",
+  };
+}
+
 module.exports = (env) => {
   return {
     mode: "development",
@@ -82,7 +106,10 @@ module.exports = (env) => {
             {
               loader: "babel-loader",
               options: {
-                presets: ["@babel/preset-env", "@babel/preset-react"],
+                presets: [
+                  "@babel/preset-env",
+                  ["@babel/preset-react", { runtime: "automatic" }],
+                ],
               },
             },
           ],
@@ -90,11 +117,7 @@ module.exports = (env) => {
         {
           test: /\.ts(x?)$/,
           exclude: /node_modules/,
-          use: [
-            {
-              loader: "ts-loader",
-            },
-          ],
+          use: [getLoaders(env)],
         },
         {
           test: /\.m?js/,

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -51,31 +51,9 @@ function getAliasesForLocalDependencies(env) {
   return aliases;
 }
 
-/**
- * Returns loader for 'ts' and 'tsx' files.
- * If we are using '--deck' or '--loaders' env variables we should avoid TypeScript issues from deck.gl or loaders.gl folder.
- * TODO: We should always use ts-loader once all issues with deck.gl and loaders.gl types have been resolved.
- */
-function getLoaders(env) {
-  // Use simple babel loader without typescript to avoid local deck.gl or loader.gl typing issues.
-  if (env["deck"] || env["loaders"]) {
-    return {
-      loader: "babel-loader",
-      options: {
-        presets: [
-          "@babel/preset-env",
-          ["@babel/preset-react", { runtime: "automatic" }],
-        ],
-      },
-    };
-  }
-
-  return {
-    loader: "ts-loader",
-  };
-}
-
 module.exports = (env) => {
+  const transpileOnly = env["deck"] || env["loaders"];
+
   return {
     mode: "development",
     entry: [
@@ -117,7 +95,14 @@ module.exports = (env) => {
         {
           test: /\.ts(x?)$/,
           exclude: /node_modules/,
-          use: [getLoaders(env)],
+          use: [
+            {
+              loader: "ts-loader",
+              options: {
+                transpileOnly,
+              },
+            },
+          ],
         },
         {
           test: /\.m?js/,

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -53,12 +53,12 @@ function getAliasesForLocalDependencies(env) {
 
 /**
  * Returns loader for 'ts' and 'tsx' files.
- * If we are using '--deck' env variable we should avoid TypeScript issues from deck.gl folder.
- * TODO: We should always use ts-loader once all issues with deck.gl types have been resolved.
+ * If we are using '--deck' or '--loaders' env variables we should avoid TypeScript issues from deck.gl or loaders.gl folder.
+ * TODO: We should always use ts-loader once all issues with deck.gl and loaders.gl types have been resolved.
  */
 function getLoaders(env) {
-  // Use simple babel loader without typescript to avoid local deck.gl typing issues.
-  if (env["deck"]) {
+  // Use simple babel loader without typescript to avoid local deck.gl or loader.gl typing issues.
+  if (env["deck"] || env["loaders"]) {
     return {
       loader: "babel-loader",
       options: {


### PR DESCRIPTION
In deck.gl there are a lot of typescript issues in multiple files.
Current project setup can't handle such issues in `yarn start-local-deck` mode.
To prevent such issues just disable `ts-loader` for now.