### PR TITLE
chore: make EXAMPLES in array representation

### DIFF
--- a/src/components/control-panel/controlPanel.tsx
+++ b/src/components/control-panel/controlPanel.tsx
@@ -121,30 +121,29 @@ export const ControlPanel = ({
   useTerrainLayer,
   toggleTerrain,
   debugMode = false,
-  tileset
+  tileset,
 }) => {
-  const {id, name} = tileset;
+  const { id, name } = tileset;
   const [example, setExample] = useState(id);
   const [, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     if (id) {
       setExample(id);
-      setSearchParams({tileset: id})
+      setSearchParams({ tileset: id });
     }
-  }, [id])
+  }, [id]);
 
   const handleChangeExample = (event) => {
     const selectedExample = event.target.value;
     setExample(selectedExample);
-    onExampleChange(EXAMPLES[selectedExample]);
+    onExampleChange(EXAMPLES.find(({ id }) => id === selectedExample));
   };
 
   const renderExampleOptions = () => {
-    return Object.keys(EXAMPLES).map((key) => {
-      const example = EXAMPLES[key];
+    return EXAMPLES.map((example) => {
       return (
-        <option key={key} value={example.id}>
+        <option key={example.id} value={example.id}>
           {example.name}
         </option>
       );
@@ -162,7 +161,11 @@ export const ControlPanel = ({
   };
 
   const renderExamples = () => (
-    <TilesetDropDown id="tilesets" value={example} onChange={handleChangeExample}>
+    <TilesetDropDown
+      id="tilesets"
+      value={example}
+      onChange={handleChangeExample}
+    >
       {name === CUSTOM_EXAMPLE_VALUE && (
         <option key={"custom-example"} value={"custom-example"}>
           {CUSTOM_EXAMPLE}

--- a/src/constants/i3s-examples.ts
+++ b/src/constants/i3s-examples.ts
@@ -1,55 +1,29 @@
-const VIEW_STATE = {
-  height: 600,
-  width: 800,
-  pitch: 45,
-  maxPitch: 60,
-  bearing: 0,
-  minZoom: 2,
-  maxZoom: 30,
-  zoom: 14.5,
-};
+import { LayerExample } from "../utils/types";
 
-export const INITIAL_EXAMPLE_NAME = "san-francisco-v1.7";
+export const TRANSITION_DURATION = 4000;
 export const CUSTOM_EXAMPLE_VALUE = "custom-example";
 
+export const INITIAL_EXAMPLE: LayerExample = {
+  id: "san-francisco-v1.7",
+  name: "San Francisco v1.7",
+  url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
+};
 
-export const EXAMPLES = {
-  "san-francisco-v1.6": {
+export const EXAMPLES: LayerExample[] = [
+  {
     id: "san-francisco-v1.6",
     name: "San Francisco v1.6",
     url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer/layers/0",
-    viewport: {
-      ...VIEW_STATE,
-      longitude: -120,
-      latitude: 34,
-    },
   },
-  "san-francisco-v1.7": {
-    id: "san-francisco-v1.7",
-    name: "San Francisco v1.7",
-    url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
-    viewport: {
-      ...VIEW_STATE,
-      longitude: -120,
-      latitude: 34,
-    },
-  },
-  "new-york": {
+  INITIAL_EXAMPLE,
+  {
     id: "new-york",
     name: "New York",
     url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0",
-    viewport: {
-      ...VIEW_STATE,
-      longitude: -74,
-      latitude: 40,
-    },
   },
-  building: {
+  {
     id: "building",
     name: "Building",
     url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Admin_Building_v17/SceneServer/layers/0",
-    viewport: {
-      ...VIEW_STATE,
-    },
   },
-};
+];

--- a/src/pages/debug-app/debug-app.tsx
+++ b/src/pages/debug-app/debug-app.tsx
@@ -31,9 +31,9 @@ import {
   useForceUpdate,
 } from "../../utils";
 import {
-  INITIAL_EXAMPLE_NAME,
   EXAMPLES,
   CUSTOM_EXAMPLE_VALUE,
+  INITIAL_EXAMPLE,
 } from "../../constants/i3s-examples";
 
 import {
@@ -278,11 +278,12 @@ export const DebugApp = () => {
       };
     }
 
-    if (tilesetParam in EXAMPLES) {
-      return EXAMPLES[tilesetParam];
+    const namedExample = EXAMPLES.find(({ id }) => tilesetParam === id);
+    if (namedExample) {
+      return namedExample;
     }
 
-    return EXAMPLES[INITIAL_EXAMPLE_NAME];
+    return INITIAL_EXAMPLE;
   };
 
   const [mainTileset, setMainTileset] = useState(initMainTileset());

--- a/src/pages/viewer-app/viewer-app.tsx
+++ b/src/pages/viewer-app/viewer-app.tsx
@@ -21,10 +21,7 @@ import {
 } from "@loaders.gl/i3s";
 import { StatsWidget } from "@probe.gl/stats-widget";
 
-import {
-  ControlPanel,
-  BuildingExplorer,
-} from "../../components";
+import { ControlPanel, BuildingExplorer } from "../../components";
 import {
   parseTilesetFromUrl,
   parseTilesetUrlParams,
@@ -36,12 +33,13 @@ import {
 } from "../../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
-import { INITIAL_EXAMPLE_NAME, EXAMPLES } from "../../constants/i3s-examples";
+import { INITIAL_EXAMPLE, EXAMPLES } from "../../constants/i3s-examples";
 import { INITIAL_MAP_STYLE } from "../../constants/map-styles";
 import { CUSTOM_EXAMPLE_VALUE } from "../../constants/i3s-examples";
 import { Tile3D, Tileset3D } from "@loaders.gl/tiles";
 import { TileDetailsPanel } from "../../components/tile-details-panel/tile-details-panel";
 import { FeatureAttributes } from "../../components/feature-attributes/feature-attributes";
+import { LayerExample } from "../../utils/types";
 
 const TRANSITION_DURAITON = 4000;
 
@@ -145,7 +143,7 @@ export const ViewerApp = () => {
     useState<StatsWidget | null>(null);
   const [loadedTilesets, setLoadedTilesets] = useState<Tileset3D[]>([]);
 
-  const initMainTileset = () => {
+  const initMainTileset = (): LayerExample => {
     const tilesetParam = parseTilesetFromUrl();
 
     if (tilesetParam?.startsWith("http")) {
@@ -159,7 +157,7 @@ export const ViewerApp = () => {
       return EXAMPLES[tilesetParam];
     }
 
-    return EXAMPLES[INITIAL_EXAMPLE_NAME];
+    return INITIAL_EXAMPLE;
   };
 
   const [mainTileset, setMainTileset] = useState(initMainTileset());

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,30 +7,37 @@ export type TileWarning = {
 };
 
 export type TileValidationData = {
-  positions: Float32Array,
-  boundingType: string,
-  boundingVolume: OrientedBoundingBox | BoundingSphere
+  positions: Float32Array;
+  boundingType: string;
+  boundingVolume: OrientedBoundingBox | BoundingSphere;
 };
 
 export type ObbData = {
-  center: number[],
-  halfSize: number[]
-  quaternion: number[]
+  center: number[];
+  halfSize: number[];
+  quaternion: number[];
 };
 
 export type GeometryVSTextureMetrics = {
   triangles: number;
-  geometryNullTriangleCount: number,
-  geometrySmallTriangleCount: number,
-  texCoordNullTriangleCount: number,
-  texCoordSmallTriangleCount: number,
-  minGeometryArea: number,
-  minTexCoordArea: number,
-  pixelArea: number,
+  geometryNullTriangleCount: number;
+  geometrySmallTriangleCount: number;
+  texCoordNullTriangleCount: number;
+  texCoordSmallTriangleCount: number;
+  minGeometryArea: number;
+  minTexCoordArea: number;
+  pixelArea: number;
 };
 
 export type LayoutProperties = {
   default: string | number;
   tablet: string | number;
   mobile: string | number;
+};
+
+export type LayerExample = {
+  id?: string;
+  name: string;
+  url: string;
+  token?: string;
 };


### PR DESCRIPTION
Motivation:
* When we store `Examples` as <key>: <object> map, the key duplicates `id` parameter;
* In some pieces of code we use this map as array, iterating over `Object.keys` or `Object.values`