### PR TITLE
fix(useSearchParams): don't set encoded tileset url into browser

### DIFF
--- a/src/components/control-panel/controlPanel.tsx
+++ b/src/components/control-panel/controlPanel.tsx
@@ -130,7 +130,12 @@ export const ControlPanel = ({
   useEffect(() => {
     if (id) {
       setExample(id);
-      setSearchParams({ tileset: id });
+
+      const isTilesetUrl = id.startsWith("http");
+
+      if (!isTilesetUrl) {
+        setSearchParams({ tileset: id });
+      }
     }
   }, [id]);
 


### PR DESCRIPTION
Don't set tileset url as param because it is replaced by special characters for example:
`https%3A%2F%2Flocalhost%2Ftiles%2FP3ePLMYs2RVChkJx%2Farcgis%2Frest%2Fservices%2FBatchedTextured1%2FSceneServer%2Flayers%2F0&token=12345`