### PR TITLE
chore(deck.gl-i3s): decrease initial zoom

### DIFF
--- a/src/components/deck-gl-i3s/deck-gl-i3s.tsx
+++ b/src/components/deck-gl-i3s/deck-gl-i3s.tsx
@@ -446,7 +446,7 @@ export const DeckGlI3s = ({
       const newViewState = {
         main: {
           ...viewState.main,
-          zoom: zoom + 2.5,
+          zoom: zoom + 2,
           longitude: pLongitue,
           latitude: pLatitude,
           transitionDuration: TRANSITION_DURAITON,


### PR DESCRIPTION
It will help to BSL layer, but doesn't really help to London tileset.