### PR TITLE
fix(compare): allow compare after compare run

### DIFF
--- a/src/pages/comparison/comparison.tsx
+++ b/src/pages/comparison/comparison.tsx
@@ -128,8 +128,6 @@ export const Comparison = ({ mode }: ComparisonPageProps) => {
     if (compareButtonMode === CompareButtonMode.Comparing) {
       setLeftSideLoaded(false);
       setPreventTransitions(true);
-    } else {
-      setDisableButton([true, true]);
     }
   }, [compareButtonMode]);
 


### PR DESCRIPTION
Actual behavior:
- after comparison: to start new comparison the user has to change veiwState until new tiles are loaded;

New behavior:
- after comparsion: the user can start new comparison instantly.

This PR fixes Turanga library comparsion. On Turanga all tiles are loaded from the start of comparison so it is impossible to cause loading new tiles with changing viewState.